### PR TITLE
Updated RFC2047-Ruby to No Longer Rely on Iconv

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in evented-imap.gemspec
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,16 @@
+PATH
+  remote: .
+  specs:
+    rfc2047 (0.2)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    rake (10.1.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rake
+  rfc2047!

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,8 @@
+require 'rake/testtask'
+
+Rake::TestTask.new do |t|
+  t.libs = ["lib"]
+  t.warning = true
+  t.verbose = true
+  t.test_files = FileList['test/*.rb']
+end

--- a/lib/rfc2047.rb
+++ b/lib/rfc2047.rb
@@ -10,8 +10,6 @@
 #
 # This file is distributed under the same terms as Ruby.
 
-require 'iconv'
-
 module Rfc2047
 
   WORD = /=\?([!#$\%&'*+-\/0-9A-Z\\^\`a-z{|}~]+)\?([BbQq])\?([!->@-~]+)\?=/ # :nodoc:
@@ -45,7 +43,7 @@ module Rfc2047
       #
       # Remember: Iconv.open(to, from)
       begin
-        text = Iconv.open(target, cs) {|i| i.iconv(text)}
+        text = text.encode(target, cs)
       rescue 
         raise Unparseable, from
       end

--- a/rfc2047.gemspec
+++ b/rfc2047.gemspec
@@ -10,4 +10,6 @@ Gem::Specification.new do |s|
   s.license = "Ruby"
   s.files = ["lib/rfc2047.rb", "README.md"]
   s.require_path = "lib"
+
+  s.add_development_dependency "rake"
 end

--- a/test/rfc2047_test.rb
+++ b/test/rfc2047_test.rb
@@ -1,7 +1,6 @@
+# encoding: UTF-8
 
-#!/usr/bin/ruby -w
-
-require 'lib/rfc2047'
+require './lib/rfc2047'
 require 'test/unit'
 
 =begin
@@ -50,12 +49,12 @@ class TestVcard < Test::Unit::TestCase
       },
 
       '=?ISO-8859-1?Q?Keld_J=F8rn_Simonsen?= <keld / dkuug.dk>' => {
-        'iso-8859-1' => "Keld J\xF8rn Simonsen <keld / dkuug.dk>",
+        'iso-8859-1' => "Keld J\xF8rn Simonsen <keld / dkuug.dk>".force_encoding("iso-8859-1"),
         'utf-8' => "Keld J\303\270rn Simonsen <keld / dkuug.dk>"
       },
 
       '=?ISO-8859-1?Q?Andr=E9?= Pirard <PIRARD / vm1.ulg.ac.be>' => {
-        'iso-8859-1' => "Andr\xe9 Pirard <PIRARD / vm1.ulg.ac.be>",
+        'iso-8859-1' => "Andr\xe9 Pirard <PIRARD / vm1.ulg.ac.be>".force_encoding("iso-8859-1"),
       },
 
       '=?ISO-8859-1?B?SWYgeW91IGNhbiByZWFkIHRoaXMgeW8=?= =?ISO-8859-2?B?dSB1bmRlcnN0YW5kIHRoZSBleGFtcGxlLg==?=' => {
@@ -66,15 +65,15 @@ class TestVcard < Test::Unit::TestCase
         'utf-8' => %(Re: Your tweet: rapportive \342\200\224 "@rapportive still use it every day")
       },
 
-      '=?ISO-8859-1?Q?Olle_J=E4rnefors?= <ojarnef / admin.kth.se>' => {'iso-8859-1' => "Olle J\xE4rnefors <ojarnef / admin.kth.se>",
+      '=?ISO-8859-1?Q?Olle_J=E4rnefors?= <ojarnef / admin.kth.se>' => {'iso-8859-1' => "Olle J\xE4rnefors <ojarnef / admin.kth.se>".force_encoding("iso-8859-1"),
       },
 
       '=?ISO-8859-1?Q?Patrik_F=E4ltstr=F6m?= <paf / nada.kth.se>' => {
-        'iso-8859-1' => "Patrik F\xE4ltstr\xF6m <paf / nada.kth.se>",
+        'iso-8859-1' => "Patrik F\xE4ltstr\xF6m <paf / nada.kth.se>".force_encoding("iso-8859-1"),
       },
 
       'Nathaniel Borenstein <nsb / thumper.bellcore.com> (=?iso-8859-8?b?7eXs+SDv4SDp7Oj08A==?=)' => {
-        'iso-8859-8' => "Nathaniel Borenstein <nsb / thumper.bellcore.com> (\355\345\354\371 \357\341 \351\354\350\364\360)",
+        'iso-8859-8' => "Nathaniel Borenstein <nsb / thumper.bellcore.com> (\355\345\354\371 \357\341 \351\354\350\364\360)".force_encoding("iso-8859-8"),
         'utf-8'      => "Nathaniel Borenstein <nsb / thumper.bellcore.com> (\327\235\327\225\327\234\327\251 \327\237\327\221 \327\231\327\234\327\230\327\244\327\240)",
       },
 


### PR DESCRIPTION
- I've switched to using String.encode rather than iconv, iconv no longer seems to work in ruby 1.9.3+.
- I added a Gemfile, and a Rakefile for tests, to get up and running:
  - bundle
  - bundle exec rake test.
