### PR TITLE
fixes #4 (warnings)

### DIFF
--- a/lib/rfc2047.rb
+++ b/lib/rfc2047.rb
@@ -15,7 +15,7 @@ module Rfc2047
   WORD = /=\?([!#$\%&'*+-\/0-9A-Z\\^\`a-z{|}~]+)\?([BbQq])\?([!->@-~]+)\?=/ # :nodoc:
 
   # Look for two adjacent words in the same encoding.
-  ADJACENT_WORDS = /(#{WORD})[\s\r\n]+(?==\?(\2)\?([BbQq])\?)/
+  ADJACENT_WORDS = /(#{WORD})\s+(?==\?(\2)\?([BbQq])\?)/
 
   # Decodes a string, +from+, containing RFC 2047 encoded words into a target
   # character set, +target+ defaulting to utf-8. See iconv_open(3) for information on the

--- a/test/rfc2047_test.rb
+++ b/test/rfc2047_test.rb
@@ -44,8 +44,7 @@ class TestVcard < Test::Unit::TestCase
       '=?US-ASCII?Q?Keith_Moore?= <moore / cs.utk.edu>' => {
         'utf-8' => 'Keith Moore <moore / cs.utk.edu>',
         'ascii' => 'Keith Moore <moore / cs.utk.edu>',
-        'us-ascii' => 'Keith Moore <moore / cs.utk.edu>',
-        'ascii' => 'Keith Moore <moore / cs.utk.edu>',
+        'us-ascii' => 'Keith Moore <moore / cs.utk.edu>'
       },
 
       '=?ISO-8859-1?Q?Keld_J=F8rn_Simonsen?= <keld / dkuug.dk>' => {


### PR DESCRIPTION
- Fix the dupl class range warning in ADJACENT_WORDS:  \s contains \r\n, and thus [\s\r\n]  can be replaced by \s.

- Additionaly fix a warning in the testcase